### PR TITLE
Update rollback information

### DIFF
--- a/rollbacks.md
+++ b/rollbacks.md
@@ -1,13 +1,18 @@
 # 🔥 Firestarter: Rollbacks
-Sometinmes unrecoverable disaster may occur with either your builds or your inventory which require admin action to resolve. On Firestarter, our admins are equipped with advanced rollback tools that can help restore your hard work in certain situations. However, we don't offer rollbacks in all situations, so have a read over this rollback guide to find out when you are eligibile.
+Sometimes unrecoverable disaster may occur with either your builds or your inventory which require admin action to resolve. On Firestarter, our admins are equipped with advanced rollback tools that can help restore your hard work in certain situations. However, we don't offer rollbacks in all situations, so have a read over this rollback guide to find out when you are eligible.
 
 ## Server-related issues
 If an unintended bug caused directly by the server (i.e. plugin issue, admin mishap, etc.) causes you to lose your inventory contents, admins are able to rollback your inventory to the last available state. Inventory backups are only saved for a short amount of time, so inquire on getting your inventory rolled back as soon as possible.
+
+Same deal goes for loss of builds.
 
 ## Grief
 Disaster strikes and your build is ruined! Admins are able to roll back your build a select amount of time to bring it back to its previous state. However, build rollbacks are not always perfect and may result in complex builds being slightly different after being rolled back. This may include missing chest contents, incorrectly rotated blocks, etc.
 
 However, this is usually only an issue with complex redstone contraptions and in most normal builds this is a non-issue.
+
+## Rollbacks on unclaimed land
+Only claimed builds are eligible for rollbacks. However, as a kind gesture, admins will be able to roll back your first grief on unclaimed land. From thereon out, you will only be eligible for rollbacks on claimed land.
 
 ## Ineligible causes
 We do not perform rollbacks on most player-initiated causes (aside from grief, of course). This is a short list of causes that would not be eligible for a rollback:

--- a/rollbacks.md
+++ b/rollbacks.md
@@ -1,0 +1,17 @@
+# 🔥 Firestarter: Rollbacks
+Sometinmes unrecoverable disaster may occur with either your builds or your inventory which require admin action to resolve. On Firestarter, our admins are equipped with advanced rollback tools that can help restore your hard work in certain situations. However, we don't offer rollbacks in all situations, so have a read over this rollback guide to find out when you are eligibile.
+
+## Server-related issues
+If an unintended bug caused directly by the server (i.e. plugin issue, admin mishap, etc.) causes you to lose your inventory contents, admins are able to rollback your inventory to the last available state. Inventory backups are only saved for a short amount of time, so inquire on getting your inventory rolled back as soon as possible.
+
+## Grief
+Disaster strikes and your build is ruined! Admins are able to roll back your build a select amount of time to bring it back to its previous state. However, build rollbacks are not always perfect and may result in complex builds being slightly different after being rolled back. This may include missing chest contents, incorrectly rotated blocks, etc.
+
+However, this is usually only an issue with complex redstone contraptions and in most normal builds this is a non-issue.
+
+## Ineligible causes
+We do not perform rollbacks on most player-initiated causes (aside from grief, of course). This is a short list of causes that would not be eligible for a rollback:
+* A player stole items from one of your chests.
+* You died from void damage and lost all of your items.
+* Your items despawned because you died over 5 minutes ago and were idling.
+* You accidentally blew up part of your house because you forgot you had claim explosions enabled.

--- a/rules.md
+++ b/rules.md
@@ -15,7 +15,7 @@ By playing on Firestarter Realms, you agree to the following rules. If you notic
 * Raiding unclaimed containers (chests, barrels, anything that stores items) is alright, so long as they are not shop chests.
 * Breaking blocks that you did not place, even in unclaimed lands, is bannable. This includes spawners that are not naturally generated.
 * If a player is offline for 3 or more months, you may ask an admin to unclaim one or more of their claims and you will be able to reclaim it. Right-click with a stick on the claimed area to check the age of the claim. Once the claim is yours, you are free to build, edit, or take items. If you lack the claimblocks to reclaim, you will be denied access to the claim until you are capable of claiming it. If another user comes along with enough claimblocks after you had already asked but lacked the claimblocks, the user with the ability to reclaim will be given it. You are free to unclaim these claims at any time.
-* It is your responsibility to claim your builds. If your builds are griefed, the griefer will be punished, but your builds will not be rolled back to their previous state.
+* It is your responsibility to claim your builds. If your builds are griefed, the griefer will be punished and you are eligible for a [rollback](rollbacks.md).
 * Creating lava casts, also frequently referred to as "cobble monsters," counts as griefing and is bannable.
 * Creating teleport traps, including those intended to kill players, is bannable.
   


### PR DESCRIPTION
Players are currently not eligible for rollbacks aside from server-related inventory loss issues. This PR expands that to allow rollbacks on griefed builds.